### PR TITLE
add banned names to username spam filter

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 node_modules
+**/test/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.9.1-RELEASE
+1. Add banned names to username spam filter.
+
 ## 1.9.0-RELEASE (2021-11-08)
 
 1. Add guildId to bounty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.9.1-RELEASE
+## 1.10.0-SNAPSHOT
 1. Add banned names to username spam filter.
 
 ## 1.9.0-RELEASE (2021-11-08)

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -64,7 +64,7 @@ function initializeClient(): Client {
 			Intents.FLAGS.DIRECT_MESSAGES,
 			Intents.FLAGS.DIRECT_MESSAGE_REACTIONS,
 		],
-		partials: ['MESSAGE', 'CHANNEL', 'REACTION'],
+		partials: ['MESSAGE', 'CHANNEL', 'REACTION', 'USER'],
 	};
 	return new Discord.Client(clientOptions);
 }

--- a/src/app/events/UserUpdate.ts
+++ b/src/app/events/UserUpdate.ts
@@ -1,7 +1,7 @@
 import { PartialUser, User } from 'discord.js';
 import { DiscordEvent } from '../types/discord/DiscordEvent';
 import ServiceUtils from '../utils/ServiceUtils';
-import { LogUtils } from '../utils/Log';
+import Log, { LogUtils } from '../utils/Log';
 
 export default class implements DiscordEvent {
 	name = 'userUpdate';
@@ -9,6 +9,11 @@ export default class implements DiscordEvent {
 
 	async execute(oldUser: User | PartialUser, newUser: User | PartialUser): Promise<any> {
 		try {
+			if (!oldUser || !newUser) {
+				Log.log('Skipping userUpdate event because oldUser or newUser was undefined.');
+				return;
+			}
+
 			if (oldUser.partial) {
 				oldUser = await oldUser.fetch();
 			}

--- a/src/app/service/constants/constants.ts
+++ b/src/app/service/constants/constants.ts
@@ -52,4 +52,18 @@ export default Object.freeze({
 	
 	PLATFORM_TYPE_DISCORD: 'DISCORD',
 	PLATFORM_TYPE_TWITTER: 'TWITTER',
+
+	BANNED_NAMES: [
+		'admin', 
+		'support', 
+		'bankless', 
+		'banklessdao', 
+		'banklessadmin', 
+		'banklesssupport', 
+		'metamask',
+		'metamasksupport',
+		'uniswap',
+		'uniswapsupport',
+		'daopunkssupport'
+	]
 });

--- a/src/app/utils/ServiceUtils.ts
+++ b/src/app/utils/ServiceUtils.ts
@@ -177,7 +177,8 @@ const ServiceUtils = {
 
 		const username = ServiceUtils.sanitizeUsername(member.user.username);
 
-		if ((nickname && highRankingNames.includes(nickname)) || highRankingNames.includes(username)) {
+		if ((nickname && (highRankingNames.includes(nickname) || constants.BANNED_NAMES.includes(nickname))) 
+			|| highRankingNames.includes(username) || constants.BANNED_NAMES.includes(username)) {
 			const debugMessage = `Nickname: ${member.displayName}. Username: ${member.user.tag}.`;
 
 			// Fetch admin contacts

--- a/src/app/utils/ServiceUtils.ts
+++ b/src/app/utils/ServiceUtils.ts
@@ -177,7 +177,7 @@ const ServiceUtils = {
 
 		const username = ServiceUtils.sanitizeUsername(member.user.username);
 
-		if ((nickname && (highRankingNames.includes(nickname) || constants.BANNED_NAMES.includes(nickname))) 
+		if ((nickname && (highRankingNames.includes(nickname) || constants.BANNED_NAMES.includes(nickname)))
 			|| highRankingNames.includes(username) || constants.BANNED_NAMES.includes(username)) {
 			const debugMessage = `Nickname: ${member.displayName}. Username: ${member.user.tag}.`;
 


### PR DESCRIPTION
- Auto-ban users that are on banned name list.
- Ignore test directory when running docker locally to resolve errors.
- Enable `USER` partial events.
- Skip `userUpdate` event if either oldUser or newUser object is undefined.